### PR TITLE
修复相册模式中的预加载

### DIFF
--- a/lib/screens/components/ImageReader.dart
+++ b/lib/screens/components/ImageReader.dart
@@ -1472,6 +1472,7 @@ class _GalleryReaderState extends _ImageReaderContentState {
           },
         );
       },
+      allowImplicitScrolling: true,
     );
     gallery = GestureDetector(
       child: gallery,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -237,7 +237,7 @@ packages:
       name: photo_view
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0"
+    version: "0.13.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   filesystem_picker: ^2.0.0-nullsafety.0
   url_launcher: ^6.0.9
   clipboard: ^0.1.3
-  photo_view: ^0.12.0
+  photo_view: ^0.13.0
   multi_select_flutter: ^4.0.0
   flutter_datetime_picker: ^1.5.1
   modal_bottom_sheet: ^2.0.0


### PR DESCRIPTION
所以这下 #64 应该算是好了?(

### 变更
升级 photo_view 依赖到 0.13.0 版本，同时在构造方法中设置 `allowImplicitScrolling` 为 true（

### 链接
[解决方案来源](https://github.com/bluefireteam/photo_view/issues/457)

[测试包 (仅限 iOS)](https://github.com/zijianjiao2017/pikapika/releases/latest)