### PR TITLE
修复平滑缩放

### DIFF
--- a/lib/screens/components/ImageReader.dart
+++ b/lib/screens/components/ImageReader.dart
@@ -1470,6 +1470,7 @@ class _GalleryReaderState extends _ImageReaderContentState {
               },
             );
           },
+          filterQuality: FilterQuality.high,
         );
       },
       allowImplicitScrolling: true,


### PR DESCRIPTION
似乎解决了 #83 

主要原因是没有设置 filterQuality 选项，因此缩放后的图片质量变得垃圾（

### 效果

| 修补前 | <img src="https://user-images.githubusercontent.com/61231083/146187623-a205720d-0719-4871-add3-b4732bb1b90d.png"/> | <img src="https://user-images.githubusercontent.com/61231083/146187636-daa53152-2053-408f-8809-2232b6d627d8.png"/> |
| ---- | ---- | ---- |
| **修补后** | <img src="https://user-images.githubusercontent.com/61231083/146187593-f1162596-2d6a-476f-beb0-b10a286d029c.png"/> | <img src="https://user-images.githubusercontent.com/61231083/146187609-1cc5b646-a07c-4b69-bd50-f636297b179f.png"/> |

确实好了不少 ~~prpr~~（

### 链接

[解决方案来源](https://github.com/bluefireteam/photo_view/pull/228)

[测试包 (仅限 iOS)](https://github.com/zijianjiao2017/pikapika/releases/latest)